### PR TITLE
save 70 tokens

### DIFF
--- a/lib/highscore.input.lua
+++ b/lib/highscore.input.lua
@@ -1,30 +1,19 @@
 _hs_name="aaa"
 _hs_name_index=1
-_hs_name_table={1,1,1}
+_hs_name_table={0,0,0}
 
 function _hs_input_update()
-  if (btnp(0)) _hs_name_index=mid(1,_hs_name_index-1,3)
-  if (btnp(1)) _hs_name_index=mid(1,_hs_name_index+1,3)
+  _hs_name_index=mid(1,3,
+    _hs_name_index+tonum(btnp(1))-tonum(btnp(0))
+  )
 
-  if btnp(2) then
-    if _hs_name_table[_hs_name_index]==1 then
-      _hs_name_table[_hs_name_index]=#_hs_chars
-    else
-      _hs_name_table[_hs_name_index]-=1
-    end
-  end
-
-  if btnp(3) then
-    if _hs_name_table[_hs_name_index]==#_hs_chars then
-      _hs_name_table[_hs_name_index]=1
-    else
-      _hs_name_table[_hs_name_index]+=1
-    end
-  end
+  _hs_name_table[_hs_name_index]=(
+    _hs_name_table[_hs_name_index]+tonum(btnp(3))-tonum(btnp(2))
+  )%#_hs_chars
 
   _hs_name=""
   for i in all(_hs_name_table) do
-    _hs_name=_hs_name..sub(_hs_chars,i,i)
+    _hs_name..=sub(_hs_chars,i+1,i+1)
   end
 
   highscore.input.name=_hs_name

--- a/lib/highscore.lua
+++ b/lib/highscore.lua
@@ -76,7 +76,7 @@ function _hs_add(name, score)
     _hs_last_index=index
 
     add(_hs_records,{name=name,score=score},index)
-    _hs_records[_hs_max_records]=nil
+    _hs_records[_hs_max_records+1]=nil
     _hs_save()
   end
 end

--- a/lib/highscore.lua
+++ b/lib/highscore.lua
@@ -18,15 +18,15 @@ function _hs_char_index(char)
 end
 
 function _hs_save()
-  for i=0,#_hs_records-1 do
-    if _hs_records[i+1] then
-      local addr=_hs_memory_addr+_hs_bytesize*i
-      for n=1,3 do
-        poke(addr+n-1,_hs_char_index(sub(_hs_records[i+1].name,n,n)))
-      end
-      poke2(addr+3,_hs_records[i+1].score)
-    end
-  end
+ for i,record in ipairs(_hs_records) do
+   if record then
+     local addr=_hs_memory_addr+_hs_bytesize*(i-1)
+     for n=1,3 do
+       poke(addr+n-1,_hs_char_index(sub(record.name,n,n)))
+     end
+     poke2(addr+3,record.score)
+   end
+ end
 
   _hs_update_table()
 end
@@ -44,17 +44,17 @@ function _hs_load()
     local addr=_hs_memory_addr+_hs_bytesize*i
     for n=0,2 do
       local v=peek(addr+n) or 1
-      name=name..sub(_hs_chars,v,v)
+      name..=sub(_hs_chars,v,v)
     end
-    _hs_records[i+1]={name=name,score=peek2(addr+3)}
+    add(_hs_records,{name=name,score=peek2(addr+3)})
   end
 
   _hs_update_table()
 end
 
 function _hs_index(score)
-  for i=1,#_hs_records do
-    if score>tonum(_hs_records[i].score) then
+  for i,record in ipairs(_hs_records) do
+    if score>tonum(record.score) then
       return i
     end
   end
@@ -75,11 +75,8 @@ function _hs_add(name, score)
   if index then
     _hs_last_index=index
 
-    for i=_hs_max_records,index+1,-1 do
-      _hs_records[i]=_hs_records[i-1]
-    end
-
-    _hs_records[index]={name=name,score=score}
+    add(_hs_records,{name=name,score=score},index)
+    _hs_records[_hs_max_records]=nil
     _hs_save()
   end
 end

--- a/lib/highscore.table.lua
+++ b/lib/highscore.table.lua
@@ -5,26 +5,27 @@ end
 function _hs_pad(string,length,char)
 	string=tostr(string)
 	char=char or "0"
-  if (#string==length) return string
-  return char.._hs_pad(string,length-1,char)
+	while #string<length do
+		string=char..string
+	end
+	return string
 end
 
 function _hs_table_draw(x,y)
-  y=y or 16
-	for i=1,#_hs_records do
+	y=y or 16
+	for i,record in ipairs(_hs_records) do
 		local y=16+i*8
-		local record=_hs_records[i]
-    local padded_score=_hs_pad(record.score,20,".")
-    local text=record.name..padded_score
+		local padded_score=_hs_pad(record.score,20,".")
+		local text=record.name..padded_score
 		if (x) print(text,x,y) else _hs_printc(text,y)
 
 		if _hs_last_index>0 and _hs_last_index==i then
-	    local x=x or 64-((#text/2)*4)
+			local x=x or 64-((#text/2)*4)
 			? "★",x-10,y,7
 		end
 	end
 end
 
 highscore.table={
-  draw=_hs_table_draw
+	draw=_hs_table_draw
 }


### PR DESCRIPTION
these are mostly just local optimizations (i.e. no large-scale re-architecting)

there shouldn't be any behavioral changes, and I didn't see any in some limited testing

this shrinks the example cart from 939 tokens to 869 (measured using the `info` command). the example cart seems to use 318 tokens (judging by the status bar inside pico-8), so the library shrunk from 621 tokens to 551 tokens, which means the library's token size has shrunk by ~11% 

this is a nice library! hope this PR is useful :)